### PR TITLE
Add Novo button to AlunoForm

### DIFF
--- a/AlunoForm.Designer.vb
+++ b/AlunoForm.Designer.vb
@@ -21,6 +21,7 @@ Partial Class AlunoForm
         Me.btnAdicionar = New System.Windows.Forms.Button()
         Me.btnAtualizar = New System.Windows.Forms.Button()
         Me.btnExcluir = New System.Windows.Forms.Button()
+        Me.btnNovo = New System.Windows.Forms.Button()
         CType(Me.dgvAlunos, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
@@ -146,13 +147,21 @@ Partial Class AlunoForm
         Me.btnExcluir.TabIndex = 13
         Me.btnExcluir.Text = "Excluir"
         Me.btnExcluir.UseVisualStyleBackColor = True
+
+        'btnNovo
+        Me.btnNovo.Location = New System.Drawing.Point(340, 116)
+        Me.btnNovo.Name = "btnNovo"
+        Me.btnNovo.Size = New System.Drawing.Size(75, 23)
+        Me.btnNovo.TabIndex = 14
+        Me.btnNovo.Text = "Novo"
+        Me.btnNovo.UseVisualStyleBackColor = True
         '
         'btnVoltar
         '
         Me.btnVoltar.Location = New System.Drawing.Point(12, 386)
         Me.btnVoltar.Name = "btnVoltar"
         Me.btnVoltar.Size = New System.Drawing.Size(75, 23)
-        Me.btnVoltar.TabIndex = 14
+        Me.btnVoltar.TabIndex = 15
         Me.btnVoltar.Text = "Voltar"
         Me.btnVoltar.UseVisualStyleBackColor = True
         '
@@ -162,6 +171,7 @@ Partial Class AlunoForm
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(584, 415)
         Me.Controls.Add(Me.btnVoltar)
+        Me.Controls.Add(Me.btnNovo)
         Me.Controls.Add(Me.btnExcluir)
         Me.Controls.Add(Me.btnAtualizar)
         Me.Controls.Add(Me.btnAdicionar)
@@ -198,5 +208,6 @@ Partial Class AlunoForm
     Friend WithEvents btnAdicionar As Button
     Friend WithEvents btnAtualizar As Button
     Friend WithEvents btnExcluir As Button
+    Friend WithEvents btnNovo As Button
     Friend WithEvents btnVoltar As Button
 End Class

--- a/AlunoForm.vb
+++ b/AlunoForm.vb
@@ -18,6 +18,10 @@ Public Class AlunoForm
         txtEmail.Clear()
         txtTelefone.Clear()
         cboCursos.SelectedIndex = -1
+        btnAdicionar.Enabled = False
+        btnAtualizar.Enabled = False
+        btnExcluir.Enabled = False
+        dgvAlunos.ClearSelection()
     End Sub
 
     Private Sub CarregarAlunos()
@@ -126,6 +130,11 @@ Public Class AlunoForm
         End Try
     End Sub
 
+    Private Sub btnNovo_Click(sender As Object, e As EventArgs) Handles btnNovo.Click
+        LimparCampos()
+        btnAdicionar.Enabled = True
+    End Sub
+
     Private Sub dgvAlunos_SelectionChanged(sender As Object, e As EventArgs) Handles dgvAlunos.SelectionChanged
         If carregando Then
             Return
@@ -137,6 +146,9 @@ Public Class AlunoForm
             dtpDataNascimento.Value = CDate(row.Cells("DataNascimento").Value)
             txtEmail.Text = row.Cells("Email").Value.ToString()
             txtTelefone.Text = row.Cells("Telefone").Value.ToString()
+            btnAdicionar.Enabled = False
+            btnAtualizar.Enabled = True
+            btnExcluir.Enabled = True
         Else
             LimparCampos()
         End If


### PR DESCRIPTION
## Summary
- add a `Novo` button on the Aluno form
- disable and enable CRUD buttons like Curso form
- clear selection when resetting fields

## Testing
- `msbuild gestao-de-dados.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6fcdb46c8324aa37faf60fef6a96